### PR TITLE
Add server-controlled bounce physics projection

### DIFF
--- a/src/mss32/hook.cpp
+++ b/src/mss32/hook.cpp
@@ -28,6 +28,7 @@
 #include "downloading.h"
 #include "demo.h"
 #include "vmix.h"
+#include "physics.h"
 #include "debug.h"
 #include "../shared/iwd.h"
 #include "../shared/common.h"
@@ -97,6 +98,7 @@ void hook_Com_Frame()
         affinity_frame();
         competitive_frame();
         cgame_frame();
+        physics_frame();
     }
 
     // Shared & Server
@@ -312,6 +314,7 @@ bool hook_patch() {
     radar_patch();
     demo_patch();
     vmix_patch();
+    physics_patch();
 
     weapons_patch();
     // Patch server side

--- a/src/mss32/physics.cpp
+++ b/src/mss32/physics.cpp
@@ -1,0 +1,83 @@
+#include "physics.h"
+
+#include <math.h>
+
+#include "shared.h"
+#include "../shared/cod2_client.h"
+#include "../shared/cod2_shared.h"
+
+static bool physics_jumpBounceEnabled = false;
+
+static void PM_ClipVelocity_Win32(const float* velIn, const float* normal, float* velOut)
+{
+    ASM_CALL(RETURN_VOID, 0x00515430, 0, ECX(velIn), EAX(normal), EDX(velOut));
+}
+
+static void PM_ProjectVelocity(const float* velIn, const float* normal, float* velOut)
+{
+    float lengthSq2D;
+    float adjusted;
+    float newZ;
+    float lengthScale;
+
+    if (!physics_jumpBounceEnabled)
+    {
+        PM_ClipVelocity_Win32(velIn, normal, velOut);
+        return;
+    }
+
+    lengthSq2D = (float)(velIn[0] * velIn[0]) + (float)(velIn[1] * velIn[1]);
+
+    if (fabsf(normal[2]) < 0.001f || lengthSq2D == 0.0f)
+    {
+        velOut[0] = velIn[0];
+        velOut[1] = velIn[1];
+        velOut[2] = velIn[2];
+    }
+    else
+    {
+        newZ = (float)-(float)((float)(velIn[0] * normal[0]) + (float)(velIn[1] * normal[1])) / normal[2];
+        adjusted = velIn[1];
+        lengthScale = sqrtf((float)((float)(velIn[2] * velIn[2]) + lengthSq2D) / (float)((float)(newZ * newZ) + lengthSq2D));
+
+        if (lengthScale < 1.0f || newZ < 0.0f || velIn[2] > 0.0f)
+        {
+            velOut[0] = lengthScale * velIn[0];
+            velOut[1] = lengthScale * adjusted;
+            velOut[2] = lengthScale * newZ;
+        }
+    }
+}
+
+void PM_ProjectVelocity_Win32()
+{
+    const float* velIn;
+    const float* normal;
+    float* velOut;
+
+    ASM( movr, velIn, "ecx" );
+    ASM( movr, normal, "eax" );
+    ASM( movr, velOut, "edx" );
+
+    PM_ProjectVelocity(velIn, normal, velOut);
+}
+
+void physics_frame()
+{
+    if (clientState < CLIENT_STATE_PRIMED)
+    {
+        physics_jumpBounceEnabled = false;
+        return;
+    }
+
+    const char* systeminfo = CL_GetConfigString(CS_SYSTEMINFO);
+    const char* jumpBounceEnable = Info_ValueForKey(systeminfo, "jump_bounceEnable");
+    physics_jumpBounceEnabled = atoi(jumpBounceEnable) != 0;
+}
+
+void physics_patch()
+{
+    // PM_StepSlideMove: replace the CoD2 velocity clip with the CoD4-style
+    // projection used by jump_bounceEnable servers.
+    patch_call(0x00530ea5, (unsigned int)PM_ProjectVelocity_Win32);
+}

--- a/src/mss32/physics.h
+++ b/src/mss32/physics.h
@@ -1,0 +1,7 @@
+#ifndef PHYSICS_H
+#define PHYSICS_H
+
+void physics_frame();
+void physics_patch();
+
+#endif


### PR DESCRIPTION
## Summary

  Adds client-side prediction support for servers that enable CoD4-style bounce physics through `jump_bounceEnable`.

  When the server advertises `jump_bounceEnable=1` in `CS_SYSTEMINFO`, the client replaces the first `PM_ClipVelocity` call in `PM_StepSlideMove` with the CoD4-style velocity projection used by libcod2 jump
  servers. When the server advertises `0` or omits the key, the client keeps the original CoD2 behavior.

  ## Details

  - Adds a small `physics` module for the Windows client.
  - Reads `jump_bounceEnable` from `CL_GetConfigString(CS_SYSTEMINFO)`.
  - Keeps the patch installed in memory, but gates behavior on the server-provided systeminfo value.
  - Only patches the first `PM_ClipVelocity` call in `PM_StepSlideMove`.
  - Falls back to original `PM_ClipVelocity` when bounce physics is disabled.
  - Does not add a local cvar or client override.

  ## Why

  Some jump servers enable CoD4-style bounce physics server-side. Without matching client prediction, CoD2 clients render/predict movement poorly on bounce maps. This lets the client follow the server-advertised
  physics mode.

  ## Compatibility

  This is backward-compatible with existing servers. Servers that do not advertise `jump_bounceEnable=1` keep normal CoD2 client prediction.

  ## Testing

  - Built Windows Release DLL through GitHub Actions on this branch.
  - Tested that the client starts with the Release DLL.
  - Verified normal servers remain on CoD2 physics when `jump_bounceEnable` is not enabled.
  - Intended server-side pairing is libcod2/jump servers where `jump_bounceEnable` is registered with `DVAR_SYSTEMINFO`.
  
## Preview

  [Watch the bounce physics preview](https://www.youtube.com/watch?v=amWKjZ_UPS4)