### PR TITLE
Cod4 bounce listen server pr

### DIFF
--- a/src/mss32/hook.cpp
+++ b/src/mss32/hook.cpp
@@ -28,6 +28,7 @@
 #include "downloading.h"
 #include "demo.h"
 #include "vmix.h"
+#include "physics.h"
 #include "debug.h"
 #include "../shared/iwd.h"
 #include "../shared/common.h"
@@ -97,6 +98,7 @@ void hook_Com_Frame()
         affinity_frame();
         competitive_frame();
         cgame_frame();
+        physics_frame();
     }
 
     // Shared & Server
@@ -312,6 +314,7 @@ bool hook_patch() {
     radar_patch();
     demo_patch();
     vmix_patch();
+    physics_patch();
 
     weapons_patch();
     // Patch server side

--- a/src/mss32/hook.cpp
+++ b/src/mss32/hook.cpp
@@ -229,6 +229,7 @@ void hook_SV_Init() {
     dvar_init();
     updater_init();
     game_init();
+    physics_init();
     animation_init();
     match_init();
     iwd_init();

--- a/src/mss32/physics.cpp
+++ b/src/mss32/physics.cpp
@@ -3,26 +3,38 @@
 #include <math.h>
 
 #include "shared.h"
-#include "../shared/cod2_client.h"
 #include "../shared/cod2_dvars.h"
-#include "../shared/cod2_shared.h"
 
 static dvar_t* jump_bounceEnable = NULL;
-static bool physics_serverJumpBounceEnabled = false;
+static bool physics_wasListenServerRunning = false;
 
 static bool physics_isListenServerRunning()
 {
     return dedicated && dedicated->value.integer == 0 && sv_running && sv_running->value.boolean;
 }
 
-static bool physics_isJumpBounceEnabled()
+static void physics_setJumpBounceWriteProtected(bool writeProtected)
 {
-    if (physics_isListenServerRunning())
+    dvarFlags_e writeProtectFlag = DEBUG_RELEASE(DVAR_CHEAT, DVAR_NOWRITE);
+
+    if (!jump_bounceEnable)
     {
-        return jump_bounceEnable && jump_bounceEnable->value.boolean;
+        return;
     }
 
-    return physics_serverJumpBounceEnabled;
+    if (writeProtected)
+    {
+        jump_bounceEnable->flags = (dvarFlags_e)(jump_bounceEnable->flags | writeProtectFlag);
+    }
+    else
+    {
+        jump_bounceEnable->flags = (dvarFlags_e)(jump_bounceEnable->flags & ~writeProtectFlag);
+    }
+}
+
+static bool physics_isJumpBounceEnabled()
+{
+    return jump_bounceEnable && jump_bounceEnable->value.boolean;
 }
 
 static void PM_ClipVelocity_Win32(const float* velIn, const float* normal, float* velOut)
@@ -81,21 +93,15 @@ void PM_ProjectVelocity_Win32()
 
 void physics_frame()
 {
-    if (physics_isListenServerRunning())
+    bool listenServerRunning = physics_isListenServerRunning();
+
+    if (physics_wasListenServerRunning && !listenServerRunning && jump_bounceEnable)
     {
-        physics_serverJumpBounceEnabled = jump_bounceEnable && jump_bounceEnable->value.boolean;
-        return;
+        Dvar_SetBool(jump_bounceEnable, false);
     }
 
-    if (clientState < CLIENT_STATE_PRIMED)
-    {
-        physics_serverJumpBounceEnabled = false;
-        return;
-    }
-
-    const char* systeminfo = CL_GetConfigString(CS_SYSTEMINFO);
-    const char* jumpBounceEnable = Info_ValueForKey(systeminfo, "jump_bounceEnable");
-    physics_serverJumpBounceEnabled = atoi(jumpBounceEnable) != 0;
+    physics_setJumpBounceWriteProtected(!listenServerRunning);
+    physics_wasListenServerRunning = listenServerRunning;
 }
 
 void physics_init()
@@ -103,13 +109,13 @@ void physics_init()
     jump_bounceEnable = Dvar_RegisterBool(
         "jump_bounceEnable",
         false,
-        (dvarFlags_e)(DVAR_SYSTEMINFO | DVAR_CHANGEABLE_RESET)
+        (dvarFlags_e)(DEBUG_RELEASE(DVAR_CHEAT, DVAR_NOWRITE) | DVAR_SYSTEMINFO | DVAR_CHANGEABLE_RESET)
     );
 }
 
 void physics_patch()
 {
     // PM_StepSlideMove: replace the CoD2 velocity clip with the CoD4-style
-    // projection used by jump_bounceEnable servers.
+    // projection controlled by the synced jump_bounceEnable dvar.
     patch_call(0x00530ea5, (unsigned int)PM_ProjectVelocity_Win32);
 }

--- a/src/mss32/physics.cpp
+++ b/src/mss32/physics.cpp
@@ -4,9 +4,26 @@
 
 #include "shared.h"
 #include "../shared/cod2_client.h"
+#include "../shared/cod2_dvars.h"
 #include "../shared/cod2_shared.h"
 
-static bool physics_jumpBounceEnabled = false;
+static dvar_t* jump_bounceEnable = NULL;
+static bool physics_serverJumpBounceEnabled = false;
+
+static bool physics_isListenServerRunning()
+{
+    return dedicated && dedicated->value.integer == 0 && sv_running && sv_running->value.boolean;
+}
+
+static bool physics_isJumpBounceEnabled()
+{
+    if (physics_isListenServerRunning())
+    {
+        return jump_bounceEnable && jump_bounceEnable->value.boolean;
+    }
+
+    return physics_serverJumpBounceEnabled;
+}
 
 static void PM_ClipVelocity_Win32(const float* velIn, const float* normal, float* velOut)
 {
@@ -20,7 +37,7 @@ static void PM_ProjectVelocity(const float* velIn, const float* normal, float* v
     float newZ;
     float lengthScale;
 
-    if (!physics_jumpBounceEnabled)
+    if (!physics_isJumpBounceEnabled())
     {
         PM_ClipVelocity_Win32(velIn, normal, velOut);
         return;
@@ -64,15 +81,30 @@ void PM_ProjectVelocity_Win32()
 
 void physics_frame()
 {
+    if (physics_isListenServerRunning())
+    {
+        physics_serverJumpBounceEnabled = jump_bounceEnable && jump_bounceEnable->value.boolean;
+        return;
+    }
+
     if (clientState < CLIENT_STATE_PRIMED)
     {
-        physics_jumpBounceEnabled = false;
+        physics_serverJumpBounceEnabled = false;
         return;
     }
 
     const char* systeminfo = CL_GetConfigString(CS_SYSTEMINFO);
     const char* jumpBounceEnable = Info_ValueForKey(systeminfo, "jump_bounceEnable");
-    physics_jumpBounceEnabled = atoi(jumpBounceEnable) != 0;
+    physics_serverJumpBounceEnabled = atoi(jumpBounceEnable) != 0;
+}
+
+void physics_init()
+{
+    jump_bounceEnable = Dvar_RegisterBool(
+        "jump_bounceEnable",
+        false,
+        (dvarFlags_e)(DVAR_SYSTEMINFO | DVAR_CHANGEABLE_RESET)
+    );
 }
 
 void physics_patch()

--- a/src/mss32/physics.cpp
+++ b/src/mss32/physics.cpp
@@ -1,0 +1,83 @@
+#include "physics.h"
+
+#include <math.h>
+
+#include "shared.h"
+#include "../shared/cod2_client.h"
+#include "../shared/cod2_shared.h"
+
+static bool physics_jumpBounceEnabled = false;
+
+static void PM_ClipVelocity_Win32(const float* velIn, const float* normal, float* velOut)
+{
+    ASM_CALL(RETURN_VOID, 0x00515430, 0, ECX(velIn), EAX(normal), EDX(velOut));
+}
+
+static void PM_ProjectVelocity(const float* velIn, const float* normal, float* velOut)
+{
+    float lengthSq2D;
+    float adjusted;
+    float newZ;
+    float lengthScale;
+
+    if (!physics_jumpBounceEnabled)
+    {
+        PM_ClipVelocity_Win32(velIn, normal, velOut);
+        return;
+    }
+
+    lengthSq2D = (float)(velIn[0] * velIn[0]) + (float)(velIn[1] * velIn[1]);
+
+    if (fabsf(normal[2]) < 0.001f || lengthSq2D == 0.0f)
+    {
+        velOut[0] = velIn[0];
+        velOut[1] = velIn[1];
+        velOut[2] = velIn[2];
+    }
+    else
+    {
+        newZ = (float)-(float)((float)(velIn[0] * normal[0]) + (float)(velIn[1] * normal[1])) / normal[2];
+        adjusted = velIn[1];
+        lengthScale = sqrtf((float)((float)(velIn[2] * velIn[2]) + lengthSq2D) / (float)((float)(newZ * newZ) + lengthSq2D));
+
+        if (lengthScale < 1.0f || newZ < 0.0f || velIn[2] > 0.0f)
+        {
+            velOut[0] = lengthScale * velIn[0];
+            velOut[1] = lengthScale * adjusted;
+            velOut[2] = lengthScale * newZ;
+        }
+    }
+}
+
+void PM_ProjectVelocity_Win32()
+{
+    const float* velIn;
+    const float* normal;
+    float* velOut;
+
+    ASM( movr, velIn, "ecx" );
+    ASM( movr, normal, "eax" );
+    ASM( movr, velOut, "edx" );
+
+    PM_ProjectVelocity(velIn, normal, velOut);
+}
+
+void physics_frame()
+{
+    if (clientState < CLIENT_STATE_PRIMED)
+    {
+        physics_jumpBounceEnabled = false;
+        return;
+    }
+
+    const char* systeminfo = CL_GetConfigString(CS_SYSTEMINFO);
+    const char* jumpBounceEnable = Info_ValueForKey(systeminfo, "jump_bounceEnable");
+    physics_jumpBounceEnabled = atoi(jumpBounceEnable) != 0;
+}
+
+void physics_patch()
+{
+    // PM_StepSlideMove: replace the CoD2 velocity clip with the CoD4-style
+    // projection used by jump_bounceEnable servers.
+    patch_call(0x00530ea5, (unsigned int)PM_ProjectVelocity_Win32);
+}

--- a/src/mss32/physics.h
+++ b/src/mss32/physics.h
@@ -1,0 +1,7 @@
+#ifndef PHYSICS_H
+#define PHYSICS_H
+
+void physics_frame();
+void physics_patch();
+
+#endif

--- a/src/mss32/physics.h
+++ b/src/mss32/physics.h
@@ -2,6 +2,7 @@
 #define PHYSICS_H
 
 void physics_frame();
+void physics_init();
 void physics_patch();
 
 #endif


### PR DESCRIPTION
## Summary

  Adds optional CoD4-style bounce physics prediction for servers/maps that enable `jump_bounceEnable`.

  The client installs the physics hook, but keeps the original CoD2 `PM_ClipVelocity` behavior unless the synced `jump_bounceEnable` dvar is enabled by the server. This keeps the feature server-controlled while
  allowing the client to predict bounce movement correctly.

## Details

  - Adds a CoD4-style `PM_ProjectVelocity` path for the first `PM_ClipVelocity` call in `PM_StepSlideMove`
  - Registers `jump_bounceEnable` as a synced dvar
  - Uses the synced local dvar value for prediction instead of parsing `CS_SYSTEMINFO` manually
  - Protects `jump_bounceEnable` from local client writes on remote servers
  - Allows local listen-server `/devmap` testing by making `jump_bounceEnable` writable only while a local server is running
  - Resets and protects `jump_bounceEnable` again when the local listen server stops
  - Falls back to original CoD2 clipping when `jump_bounceEnable` is disabled or absent

## Why

  Base CoD2 already has synced movement dvars such as `jump_slowdownEnable`, but it does not include the CoD4 bounce projection path. This adds the missing client prediction support while following the same
  server-controlled prediction model.

  This avoids a user-controlled client override: forcing bounce prediction locally while the server has it disabled can briefly show positions/angles that should not be reachable before the server corrects the
  player.

## Testing

  - Built a Windows `mss32.dll` from the test branch using GitHub Actions
  - Verified `jump_bounceEnable` can be enabled for local `/devmap` testing
  - Verified `jump_bounceEnable` is protected when connected to a remote server
  - Verified prediction follows server-enabled bounce physics
  - Verified default behavior remains CoD2 physics when `jump_bounceEnable` is disabled or absent
  
## Preview
[Watch the bounce physics preview](https://www.youtube.com/watch?v=amWKjZ_UPS4)