### PR TITLE
New cvar sv_hideServerIp to hide the server IP on the scoreboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ It focuses on fixing bugs and adding new features to the game.
     - `sv_master3` is customizable
 - New cvar `sv_cracked` to make the server accept players with invalid CDKEY
 - New cvar `showPacketStrings` to show network communication data
+- New cvar `sv_hideServerIp` to hide the server IP address at the bottom of the scoreboard (hostname stays visible), preventing the server address from leaking on streams
+  - automatically enabled when the match data contains `"hideServerIp": true`, restored when the match ends
 - New commands `/increase` and `/decrease` to increase or decrease the value of a cvar
 - Reversed function for third person, added new cvar `cg_thirdPersonMode 1` that rotates directly around player without collision with the world
 - Added possibility to set CPU affinity

--- a/src/mss32/cgame.cpp
+++ b/src/mss32/cgame.cpp
@@ -232,10 +232,29 @@ void CG_OffsetThirdPersonView( void ) {
 
 
 
+/**
+ * Replacement of the function that returns the server address string ("ip:port") drawn in the bottom right corner of the scoreboard.
+ * When the server enables sv_hideServerIp (for example while a streamed match is running), an empty string is returned
+ * so the IP address is not drawn and streams do not leak the server address. The hostname in the bottom left corner stays visible.
+ */
+const char* CG_ScoreboardServerAddress() {
+    const char* hide = Info_ValueForKey(CL_GetConfigString(CS_SERVERINFO), "sv_hideServerIp");
+    if (hide[0] == '1') {
+        return "";
+    }
+    // Call the original function returning the address of the server the client is connected to
+    return ((const char* (__cdecl*)())0x004120f0)();
+}
+
+
 /** Called before the entry point is called. Used to patch the memory. */
 void cgame_patch() {
 
     patch_call(0x004cfb27, (unsigned int)CG_OffsetThirdPersonView);
+
+    // Hook the function that returns the server address drawn at the bottom of the scoreboard,
+    // so the server can hide it via serverinfo cvar sv_hideServerIp
+    patch_call(0x004d9387, (unsigned int)CG_ScoreboardServerAddress); // 004d9387  e8648df3ff  call 0x4120f0 (inside CG_DrawScoreboard)
 
 
     // Cvar "snaps" max value change from 30 to 40

--- a/src/shared/match.cpp
+++ b/src/shared/match.cpp
@@ -15,6 +15,8 @@
 dvar_t *match_login; // Cvar to store match login hash
 Match match;
 extern bool gsc_allowOneTimeLevelChange;
+extern dvar_t* sv_hideServerIp;
+bool match_hideServerIpWasSet = false; // whether sv_hideServerIp was automatically enabled by the match
 
 
 // TODO secure vypsani uuid, aby neslo zneuzit
@@ -661,7 +663,17 @@ void match_onStartGameType() {
     if (match.loading) {
         match.loading = false;
         match.activated = true;
-        
+
+        // Hide the server IP address on the scoreboard if requested by the match data ("hideServerIp": true),
+        // so streams do not leak the server address
+        if (match.data.otherData.contains("hideServerIp")) {
+            const std::string& hide = match.data.otherData.at("hideServerIp");
+            if ((hide == "true" || hide == "1") && !sv_hideServerIp->value.boolean) {
+                Dvar_SetBool(sv_hideServerIp, true);
+                match_hideServerIpWasSet = true;
+            }
+        }
+
         Com_Printf("======================================================\n");
         Com_Printf("Match started successfully.\n");
         Com_Printf("- URL: %s\n", match.url);
@@ -721,7 +733,13 @@ bool match_beforeMapChangeOrRestart(bool fromScript, bool bComplete, bool shutdo
         match.downloading = false;
         match.progressData.globalData.clear();
         match.progressData.playerData.clear();
-        
+
+        // Restore the server IP visibility on the scoreboard if it was hidden by the match
+        if (match_hideServerIpWasSet) {
+            Dvar_SetBool(sv_hideServerIp, false);
+            match_hideServerIpWasSet = false;
+        }
+
     }
 
     return true;

--- a/src/shared/server.cpp
+++ b/src/shared/server.cpp
@@ -37,6 +37,7 @@ dvar_t*		showpacketstrings;
 dvar_t*		sv_playerBroadcastLimit;
 int 		nextIPTime = 0;
 dvar_t*		g_competitive;
+dvar_t*		sv_hideServerIp;
 bool		server_ignoreMapChangeThisFrame = false;
 
 extern dvar_t* g_cod2x;
@@ -1309,6 +1310,10 @@ void server_init()
 
 	// Maximum number of players that will be sent to all clients, if there are more players, only visible players will be sent
 	sv_playerBroadcastLimit = Dvar_RegisterInt("sv_playerBroadcastLimit", 15, 0, 64, (dvarFlags_e)(DVAR_CHANGEABLE_RESET));
+
+	// Hide the server IP address at the bottom of the scoreboard on clients, so streams do not leak the server address
+	// It is automatically enabled while a match is running
+	sv_hideServerIp = Dvar_RegisterBool("sv_hideServerIp", false, (dvarFlags_e)(DVAR_SERVERINFO | DVAR_CHANGEABLE_RESET));
 
 	// Sets limits on client side for competitive settings
 	dvarFlags_e noWriteForClientFlag = (dedicated->value.integer == 0) ? DEBUG_RELEASE(DVAR_CHEAT, DVAR_NOWRITE) : DVAR_NOFLAG;


### PR DESCRIPTION
Hides the server address shown at the bottom of the scoreboard (hostname stays visible), preventing it from leaking on streams. Automatically enabled when match data contains "hideServerIp": true, and restored when the match ends.